### PR TITLE
make `onContextReady` optional.

### DIFF
--- a/src/FileUpload.jsx
+++ b/src/FileUpload.jsx
@@ -329,7 +329,7 @@ function FileUpload(props) {
 
     if (onFilesChange) {
       onFilesChange(getBase64 ? files : originalFiles)
-      onContextReady(getContext())
+      if (onContextReady) onContextReady(getContext())
     }
     // eslint-disable-next-line
   }, [files, action])


### PR DESCRIPTION
When `onContextReady` prop is not provided, the first render was throwing `Uncaught TypeError: onContextReady is not a function`.